### PR TITLE
Claude/fix phecoder bugs 5 gdl t

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pc.run()
 pc.build_ensemble()
 
 # Load results into dataframe
-results = pc.load_results()
+results = pc.load_results('ensemble-zsum')
 ```
 
 ## A more detailed example
@@ -162,7 +162,7 @@ pc.build_ensemble(
 ### 8. Load Results
 ```python
 # Load all results (individual models + ensemble)
-results = pc.load_results(include_ensembles=True)
+results = pc.load_results()
 
 # Load ensemble results only
 ensemble_results = pc.load_results(

--- a/phecoder/phecoder.py
+++ b/phecoder/phecoder.py
@@ -118,7 +118,6 @@ class Phecoder:
 
         # Encode/search kwargs
         self.st_encode_kwargs = _clean_kwargs(st_encode_kwargs)
-        self.per_model_encode_kwargs = per_model_encode_kwargs or {}
         self.st_search_kwargs = _clean_kwargs(st_search_kwargs)
         # Sensible defaults if not provided
         self.st_encode_kwargs.setdefault("normalize_embeddings", True)
@@ -157,13 +156,12 @@ class Phecoder:
         include_ensembles: bool = True,
     ) -> pd.DataFrame:
         return load_results_utils(
-            output_dir=self.output_dir,
-            phecode_hash=self.phecode_hash,
-            phecode_df=self.phecode_df,
+            dir=self.output_dir,
             models=models,
             phecode=phecode,
             phecode_ground_truth=phecode_ground_truth,
             include_ensembles=include_ensembles,
+            run_hash=self.phecode_hash,
         )
 
     def build_ensemble(
@@ -357,7 +355,7 @@ class Phecoder:
             Columns: ['model', 'run_hash', 'created_at', 'top_k', 'run_dir']
         """
         return list_runs_utils(
-            output_dir=self.output_dir,
+            dir=self.output_dir,
             models=models,
             include_ensembles=include_ensembles,
         )


### PR DESCRIPTION
This pull request updates the way results are loaded and run directories are listed in the `phecoder` package, primarily by standardizing function argument names and simplifying result loading behavior. It also updates documentation in the `README.md` to reflect these changes.

**Documentation updates:**

* Updated code examples in `README.md` to use the new `load_results` interface, removing or changing arguments to match the updated function signature. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L61-R61) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L165-R165)

**Codebase improvements:**

* Standardized argument names from `output_dir` to `dir` in calls to `load_results_utils` and `list_runs_utils` within `phecoder.py` for consistency. [[1]](diffhunk://#diff-a1de7ddeb16cdfb13a06604c85fa2d32780ad88c07bf55225d79bc94d4ca57abL160-R164) [[2]](diffhunk://#diff-a1de7ddeb16cdfb13a06604c85fa2d32780ad88c07bf55225d79bc94d4ca57abL360-R358)
* Updated `load_results` method to pass `run_hash` instead of `phecode_hash` and removed unused arguments to streamline function calls.
* Removed unnecessary initialization of `per_model_encode_kwargs` in the `Phecoder` class constructor.