### PR TITLE
Preserve extra icd_df columns in similarity output

### DIFF
--- a/phecoder/_ensemble.py
+++ b/phecoder/_ensemble.py
@@ -367,6 +367,17 @@ def _build_ensemble_from_runs(
             "created_at",
         ],
     )
+    # Attach any extra columns carried on icd_df
+    extra_icd_cols = [c for c in icd_df.columns if c not in {"icd_code", "icd_string"}]
+    if extra_icd_cols:
+        ens_df = ens_df.merge(
+            icd_df[["icd_code"] + extra_icd_cols]
+            .assign(icd_code=lambda d: d["icd_code"].astype(str))
+            .drop_duplicates(subset="icd_code"),
+            on="icd_code",
+            how="left",
+        )
+
     ens_df.to_parquet(sim_path, index=False)
 
     # Manifest


### PR DESCRIPTION
Previously, Phecoder.__init__ dropped all columns from icd_df except icd_code and icd_string. Any additional columns the user provided (e.g. frequency, category, source) were lost. Now the full DataFrame is retained and extra columns are merged into the similarity.parquet output for both per-model runs and ensemble runs.

The ICD fingerprint (used for cache/skip logic) is still computed on only the two essential columns so that adding metadata columns does not invalidate embedding caches.

https://claude.ai/code/session_01L3hQVCXxdrWBSHoFLzmLyy